### PR TITLE
feat: add statefulset stabel schedule plugin

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling"
 	"sigs.k8s.io/scheduler-plugins/pkg/qos"
+	"sigs.k8s.io/scheduler-plugins/pkg/stateful"
 )
 
 func main() {
@@ -35,6 +36,7 @@ func main() {
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(coscheduling.Name, coscheduling.New),
 		app.WithPlugin(qos.Name, qos.New),
+		app.WithPlugin(stateful.Name, stateful.New),
 	)
 	if err := command.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/stateful/REAEME.md
+++ b/pkg/stateful/REAEME.md
@@ -1,0 +1,66 @@
+# Overview
+in some specific scenarios, statefulset hopes to be able to schedule to the same node. this plugin implement statafulset stable schedule.
+
+# demo
+1. use kind to build a multi-worker k8s cluster
+```yaml
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+```
+
+```bash
+kind create cluster --config=cluster.yaml
+```
+
+2. use multi profile of schedule and add plugin configuration
+```yaml
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+  - schedulerName: statefulset-stable
+    plugins:
+      preFilter:
+        enabled:
+          - name: statefulset-stable
+      postBind:
+        enabled:
+          - name: statefulset-stable
+```
+
+3. create a statefulset
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        statefulset-stable.scheduling.sigs.k8s.io: "true"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+              name: web
+      schedulerName: statefulset-stable
+```
+the statefulset annotation records the scheduled records. as follows, web-0 will alway schedule to kind-worker when rescheduling
+```yaml
+annotations:
+    statefulset-stable.scheduling.sigs.k8s.io/record: '{"Records":{"web-0":"kind-worker","web-1":"kind-worker2"}}'
+```

--- a/pkg/stateful/statefulset_stable.go
+++ b/pkg/stateful/statefulset_stable.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stateful
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	statefulsetlisters "k8s.io/client-go/listers/apps/v1"
+	"k8s.io/client-go/util/retry"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+var _ framework.FilterPlugin = &Stable{}
+var _ framework.PostBindPlugin = &Stable{}
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const (
+	Name                    = "statefulset-stable"
+	Kind                    = "StatefulSet"
+	StatefulsetStableRecord = "statefulset-stable.scheduling.sigs.k8s.io/record"
+	StatefulsetStable       = "statefulset-stable.scheduling.sigs.k8s.io"
+)
+
+// Stable is a plugin that implements statefulset stable schedule
+type Stable struct {
+	statefulSetLister statefulsetlisters.StatefulSetLister
+	clientset         clientset.Interface
+}
+
+type ScheduleRecord struct {
+	Records map[string]string
+}
+
+// Name returns name of the plugin.
+func (st *Stable) Name() string {
+	return Name
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
+	statefulsetLister := handle.SharedInformerFactory().Apps().V1().StatefulSets().Lister()
+	clientset := handle.ClientSet()
+	return &Stable{
+		statefulSetLister: statefulsetLister,
+		clientset:         clientset,
+	}, nil
+}
+
+// Filter checks whether the pod meets the current plugin conditions and
+// restores the last scheduled record. Filters out unmatched nodes.
+func (st *Stable) Filter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *framework.Status {
+	if !containStatefulsetStableLabel(pod) {
+		return framework.NewStatus(framework.Success, "")
+	}
+	if statefulset := st.createByStatefulset(pod); statefulset != nil {
+		// try get the pod schedule record
+		record, err := getScheduleRecord(statefulset)
+		if err != nil {
+			return framework.NewStatus(framework.Unschedulable, err.Error())
+		}
+		if record != nil {
+			if node, ok := record.Records[pod.GetName()]; ok {
+				// want to schedule to the original node, if the node is different, filter directly
+				if node != nodeInfo.Node().GetName() {
+					return framework.NewStatus(framework.Unschedulable, "")
+				}
+			}
+		}
+	}
+	return framework.NewStatus(framework.Success, "")
+}
+
+// PostBind record the result of the current schedule to the annotation of statefulset
+func (st *Stable) PostBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
+	if !containStatefulsetStableLabel(pod) {
+		return
+	}
+	// although the updates of the pods created by the statefulset are ordered and
+	// can relieve the problem of concurrent updates, but the update operation cannot guarantee success,
+	// should catch error and add retry.
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if statefulset := st.createByStatefulset(pod); statefulset != nil {
+			return st.setScheduleRecord(ctx, statefulset, pod, nodeName)
+		}
+		return nil
+	})
+	if retryErr != nil {
+		log.Printf("Failed to record scheduling result: %v\n", retryErr)
+	}
+}
+
+func containStatefulsetStableLabel(pod *v1.Pod) bool {
+	label := pod.GetLabels()
+	if label == nil {
+		return false
+	}
+	if label[StatefulsetStable] == "true" {
+		return true
+	}
+	return false
+}
+
+// createByStatefulset check if the pod belongs to statefulset, if yes, return statefulset object
+func (st *Stable) createByStatefulset(pod *v1.Pod) *appsv1.StatefulSet {
+	ows := pod.GetOwnerReferences()
+	for _, ow := range ows {
+		if ow.Kind == Kind {
+			statefulset, err := st.statefulSetLister.StatefulSets(pod.Namespace).Get(ows[0].Name)
+			if err != nil {
+				return nil
+			}
+			return statefulset
+		}
+	}
+	return nil
+}
+
+func getScheduleRecord(statefulset *appsv1.StatefulSet) (*ScheduleRecord, error) {
+	var record *ScheduleRecord
+	var err error
+	ats := statefulset.GetAnnotations()
+	if ats != nil {
+		if rec, ok := ats[StatefulsetStableRecord]; ok {
+			if err := json.Unmarshal([]byte(rec), &record); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return record, err
+}
+
+func (st *Stable) setScheduleRecord(ctx context.Context, statefulset *appsv1.StatefulSet, pod *v1.Pod, nodeName string) error {
+	needUpdate := false
+	record, err := getScheduleRecord(statefulset)
+	if err != nil {
+		return err
+	}
+	if record == nil {
+		record = new(ScheduleRecord)
+	}
+
+	if record.Records == nil {
+		record.Records = make(map[string]string)
+	}
+
+	if _, ok := record.Records[pod.GetName()]; !ok {
+		record.Records[pod.GetName()] = nodeName
+		needUpdate = true
+	}
+
+	if needUpdate {
+		statefulsetCopy := statefulset.DeepCopy()
+		recordBytes, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
+		if statefulsetCopy.Annotations == nil {
+			statefulsetCopy.Annotations = make(map[string]string)
+		}
+		statefulsetCopy.Annotations[StatefulsetStableRecord] = string(recordBytes)
+		_, err = st.clientset.AppsV1().StatefulSets(statefulset.Namespace).Update(ctx, statefulsetCopy, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/stateful/statefulset_stable_test.go
+++ b/pkg/stateful/statefulset_stable_test.go
@@ -1,0 +1,234 @@
+package stateful
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+func TestFilter(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	informers := informers.NewSharedInformerFactory(clientset, 0)
+	statefulsetInformer := informers.Apps().V1().StatefulSets()
+	statefulsetLister := statefulsetInformer.Lister()
+	stableSchedule := &Stable{
+		statefulSetLister: statefulsetLister,
+		clientset:         clientset,
+	}
+	statefulset := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web",
+			Namespace: "n1",
+			Annotations: map[string]string{
+				"statefulset-stable.scheduling.sigs.k8s.io/record": `{"Records":{"web-0":"node1"}}`,
+			},
+		},
+	}
+	err := statefulsetInformer.Informer().GetIndexer().Add(statefulset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		node     *corev1.Node
+		expected framework.Code
+	}{
+		{
+			name: "the pod is rescheduled to the node1",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+					Labels: map[string]string{
+						"statefulset-stable.scheduling.sigs.k8s.io": "true",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "StatefulSet",
+							Name: "web",
+						},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+			},
+			expected: framework.Success,
+		},
+		{
+			name: "pod web-0 unschedule to node2",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+					Labels: map[string]string{
+						"statefulset-stable.scheduling.sigs.k8s.io": "true",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "StatefulSet",
+							Name: "web",
+						},
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+			},
+			expected: framework.Unschedulable,
+		},
+		{
+			name: "owner references are not statefulset",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+					Labels: map[string]string{
+						"statefulset-stable.scheduling.sigs.k8s.io": "true",
+					},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+			},
+			expected: framework.Success,
+		},
+		{
+			name: "pod has not statefulset-stable.scheduling.sigs.k8s.io=true label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node2",
+				},
+			},
+			expected: framework.Success,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeInfo := schedulernodeinfo.NewNodeInfo()
+			err := nodeInfo.SetNode(tt.node)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res := stableSchedule.Filter(context.TODO(), nil, tt.pod, nodeInfo)
+			if res.Code() != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, res.Code())
+
+			}
+
+		})
+	}
+}
+
+func TestPostBind(t *testing.T) {
+	statefulset := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web",
+			Namespace: "n1",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(statefulset)
+	informers := informers.NewSharedInformerFactory(clientset, 0)
+	statefulsetInformer := informers.Apps().V1().StatefulSets()
+	statefulsetLister := statefulsetInformer.Lister()
+	stableSchedule := &Stable{
+		statefulSetLister: statefulsetLister,
+		clientset:         clientset,
+	}
+
+	err := statefulsetInformer.Informer().GetIndexer().Add(statefulset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name                string
+		pod                 *corev1.Pod
+		nodeName            string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "the pod scheduled to the node1, but owner references are not statefulset",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+					Labels: map[string]string{
+						"statefulset-stable.scheduling.sigs.k8s.io": "true",
+					},
+				},
+			},
+			nodeName: "node1",
+		},
+		{
+			name: "the pod scheduled to the node1, but pod has no statefulset-stable.scheduling.sigs.k8s.io=true label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+				},
+			},
+			nodeName: "node1",
+		},
+		{
+			name: "the pod scheduled to the node1",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "web-0",
+					Namespace: "n1",
+					Labels: map[string]string{
+						"statefulset-stable.scheduling.sigs.k8s.io": "true",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind: "StatefulSet",
+							Name: "web",
+						},
+					},
+				},
+			},
+			nodeName: "node1",
+			expectedAnnotations: map[string]string{
+				"statefulset-stable.scheduling.sigs.k8s.io/record": `{"Records":{"web-0":"node1"}}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			stableSchedule.PostBind(ctx, nil, tt.pod, tt.nodeName)
+			s, err := clientset.AppsV1().StatefulSets(statefulset.Namespace).Get(ctx, statefulset.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(tt.expectedAnnotations, s.Annotations) {
+				t.Errorf("expected %v, got %v", tt.expectedAnnotations, s.Annotations)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Overview
in some specific scenarios, statefulset hopes to be able to schedule to the same node. this plugin implement statafulset stable schedule.

# demo
1. use kind to build a multi-worker k8s cluster
```yaml
kind: Cluster
apiVersion: kind.sigs.k8s.io/v1alpha3
nodes:
- role: control-plane
- role: worker
- role: worker
```

```bash
kind create cluster --config=cluster.yaml
```

2. use multi profile of schedule and add plugin configuration
```yaml
apiVersion: kubescheduler.config.k8s.io/v1alpha2
kind: KubeSchedulerConfiguration
leaderElection:
  leaderElect: false
profiles:
  - schedulerName: statefulset-stable
    plugins:
      filter:
        enabled:
          - name: statefulset-stable
      postBind:
        enabled:
          - name: statefulset-stable
```

3. create a statefulset
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: web
spec:
  serviceName: "nginx"
  replicas: 2
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
        statefulset-stable.scheduling.sigs.k8s.io: "true"
    spec:
      containers:
        - name: nginx
          image: nginx:latest
          ports:
            - containerPort: 80
              name: web
      schedulerName: statefulset-stable
```
the statefulset annotation records the scheduled records. as follows, web-0 will alway schedule to kind-worker when rescheduling
```yaml
annotations:
    statefulset-stable.scheduling.sigs.k8s.io/record: '{"Records":{"web-0":"kind-worker","web-1":"kind-worker2"}}'
```
# test
```sh
➜  stateful git:(stable-schedule) ✗ go test -v  -coverprofile=cover.out
=== RUN   TestFilter
=== RUN   TestFilter/the_pod_is_rescheduled_to_the_node1
=== RUN   TestFilter/pod_web-0_unschedule_to_node2
=== RUN   TestFilter/owner_references_are_not_statefulset
=== RUN   TestFilter/pod_has_not_statefulset-stable.scheduling.sigs.k8s.io=true_label
--- PASS: TestFilter (0.00s)
    --- PASS: TestFilter/the_pod_is_rescheduled_to_the_node1 (0.00s)
    --- PASS: TestFilter/pod_web-0_unschedule_to_node2 (0.00s)
    --- PASS: TestFilter/owner_references_are_not_statefulset (0.00s)
    --- PASS: TestFilter/pod_has_not_statefulset-stable.scheduling.sigs.k8s.io=true_label (0.00s)
=== RUN   TestPostBind
=== RUN   TestPostBind/the_pod_scheduled_to_the_node1,_but_owner_references_are_not_statefulset
=== RUN   TestPostBind/the_pod_scheduled_to_the_node1,_but_pod_has_no_statefulset-stable.scheduling.sigs.k8s.io=true_label
=== RUN   TestPostBind/the_pod_scheduled_to_the_node1
--- PASS: TestPostBind (0.00s)
    --- PASS: TestPostBind/the_pod_scheduled_to_the_node1,_but_owner_references_are_not_statefulset (0.00s)
    --- PASS: TestPostBind/the_pod_scheduled_to_the_node1,_but_pod_has_no_statefulset-stable.scheduling.sigs.k8s.io=true_label (0.00s)
    --- PASS: TestPostBind/the_pod_scheduled_to_the_node1 (0.00s)
PASS
coverage: 82.4% of statements
ok  	sigs.k8s.io/scheduler-plugins/pkg/stateful	0.027s
```